### PR TITLE
fix blocking navigation when frequently switching between pages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,6 @@
 .eslintrc.js
 .eslintignore
 prettier.config.js
-# src
+src
 tsconfig.json
 dist/tsconfig.tsbuildinfo

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,6 @@
 .eslintrc.js
 .eslintignore
 prettier.config.js
-src
+# src
 tsconfig.json
 dist/tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-router-events",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A router events alternative for Next.js 13+ with app directory with the ability to prevent user navigation.",
   "author": "run4w4y <add4che@gmail.com>",
   "main": "dist/index.js",
@@ -8,8 +8,6 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",
-    "release": "standard-version --no-verify",
-    "build": "rm -rf dist && tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "release": "standard-version --no-verify",
+    "build": "rm -rf dist && tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
-    "lint:fix": "npm run lint -- --fix",
+    "lint:fix": "npm run lint -- --fix"
   },
   "repository": {
     "type": "git",

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,8 @@
 import React, { useContext } from 'react'
 import { noop } from './util'
 
+let requests: string[] = []
+
 interface FreezeRequestsContextValue {
   freezeRequests: string[]
   setFreezeRequests: React.Dispatch<React.SetStateAction<string[]>>
@@ -19,10 +21,12 @@ export const useFreezeRequestsContext = () => {
   return {
     freezeRequests,
     request: (sourceId: string) => {
-      setFreezeRequests([...freezeRequests, sourceId])
+      requests = [...requests, sourceId]
+      setFreezeRequests(requests)
     },
     revoke: (sourceId: string) => {
-      setFreezeRequests(freezeRequests.filter((x) => x !== sourceId))
+      requests = requests.filter((x) => x !== sourceId)
+      setFreezeRequests(requests)
     },
   }
 }


### PR DESCRIPTION
# Steps to produce the issue
1. When two pages use useRouteChangeEvents
2. The user switch between these two pages few times
3. The user route to other pages which doesn't have useRouteChangeEvents
4. All links in the app don't work

# Root cause
update state actions is not in-sync, when we call request => revoke => request at the same time. Actually, the state inside the blocks are the same value but not update one by one.

# How to fix
Use global variable to store the requests ID to make sure the changes is in order.